### PR TITLE
Add-object-inheritance

### DIFF
--- a/src/nxvalidate/definitions/base_classes/NXbeam.nxdl.xml
+++ b/src/nxvalidate/definitions/base_classes/NXbeam.nxdl.xml
@@ -308,7 +308,7 @@
                 </doc>
             </attribute>
         </field>
-        <field name="reference_plane" nameType="any" units="NX_TRANSFORMATION" type="NX_NUMBER">
+        <field name="REFERENCE_PLANE" nameType="any" units="NX_TRANSFORMATION" type="NX_NUMBER">
             <doc>
                 Direction of normal to reference plane used to measure azimuth relative to the beam, its value is ignored.
                 This also defines the parallel and perpendicular components of the beam's polarization.

--- a/src/nxvalidate/definitions/base_classes/NXdata.nxdl.xml
+++ b/src/nxvalidate/definitions/base_classes/NXdata.nxdl.xml
@@ -420,7 +420,7 @@
 			<doc>data label</doc>
 		</attribute>
 	</field>
-	<field name="FIELDNAME_errors" type="NX_NUMBER" nameType="any">
+	<field name="FIELDNAME_errors" type="NX_NUMBER" nameType="partial">
 		<doc>
 			"Errors" (meaning *uncertainties* or *standard deviations*)
 			associated with any field named ``FIELDNAME`` in this ``NXdata``

--- a/src/nxvalidate/definitions/base_classes/NXobject.nxdl.xml
+++ b/src/nxvalidate/definitions/base_classes/NXobject.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 # 
-# Copyright (C) 2008-2022 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
 # 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -29,6 +29,13 @@
 	<doc>
 		This is the base object of NeXus
 	</doc>
-        <!--attribute name="name"><doc>name of instance</doc></attribute-->
+    <group type="NXcollection" />
+    <group type="NXdata" />
+    <group type="NXlog" />
+    <group type="NXnote" />
+    <group type="NXparameters" />
+    <group name="GROUPNAME_log" type="NXlog" nameType="partial" />
+    <field name="FIELDNAME_errors" type="NX_NUMBER" nameType="partial" />
+    <field name="FIELDNAME_weights" type="NX_NUMBER" nameType="partial" />
 </definition>
 

--- a/src/nxvalidate/definitions/base_classes/NXroot.nxdl.xml
+++ b/src/nxvalidate/definitions/base_classes/NXroot.nxdl.xml
@@ -3,7 +3,7 @@
 <!--
 # NeXus - Neutron and X-ray Common Data Format
 #
-# Copyright (C) 2008-2022 NeXus International Advisory Committee (NIAC)
+# Copyright (C) 2008-2024 NeXus International Advisory Committee (NIAC)
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -24,8 +24,7 @@
 <definition xmlns="http://definition.nexusformat.org/nxdl/3.1" category="base"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://definition.nexusformat.org/nxdl/3.1 ../nxdl.xsd"
-    name="NXroot"
-    type="group" extends="NXobject">
+    name="NXroot" type="group">
     <doc>Definition of the root NeXus group.</doc>
     <attribute name="NX_class">
         <doc>

--- a/src/nxvalidate/definitions/base_classes/NXtransformations.nxdl.xml
+++ b/src/nxvalidate/definitions/base_classes/NXtransformations.nxdl.xml
@@ -184,7 +184,7 @@
 			</doc>
 		</attribute>
 	</field>
-	<field name="AXISNAME_end" units="NX_TRANSFORMATION" nameType="any" type="NX_NUMBER" minOccurs="0">
+	<field name="AXISNAME_end" units="NX_TRANSFORMATION" nameType="partial" type="NX_NUMBER" minOccurs="0">
 		<doc>
 			``AXISNAME_end`` is a placeholder for a name constructed from the actual
 			name of an axis to which ``_end`` has been appended.
@@ -193,7 +193,7 @@
 			at the corresponding positions given in the ``AXISNAME`` field.
 		</doc>
 	</field>
-	<field name="AXISNAME_increment_set" units="NX_TRANSFORMATION"  nameType="any" type="NX_NUMBER" minOccurs="0">
+	<field name="AXISNAME_increment_set" units="NX_TRANSFORMATION"  nameType="partial" type="NX_NUMBER" minOccurs="0">
 		<doc>
 			``AXISNAME_increment_set`` is a placeholder for a name constructed from the actual
 			name of an axis to which ``_increment_set`` has been appended.


### PR DESCRIPTION
* Adds fields and groups that are allowed in all other base classes into the NXobject base class. This will need to be ratified by the NIAC, but it should improve file validation in the meantime.
* Removes inheritance from the NXroot base class so that the new NXobject fields and groups are not considered valid.
* Converts base classes to use the new `nameType=partial` value, approved by the NIAC.