### PR TITLE
Fixes definitions directories in Python 3.8 and 3.9

### DIFF
--- a/src/nxvalidate/validate.py
+++ b/src/nxvalidate/validate.py
@@ -85,10 +85,9 @@ class Validator():
             elif isinstance(definitions, Path):
                 self.definitions = definitions.resolve()
             else:
-                self.definitions = definitions.joinpath('')
+                self.definitions = definitions
         else:
-            self.definitions = package_files(
-                'nxvalidate.definitions').joinpath('')
+            self.definitions = package_files('nxvalidate.definitions')
         self.baseclasses = self.definitions / 'base_classes'
         if not self.baseclasses.exists():
             raise NeXusError(f'"{self.baseclasses}" does not exist')


### PR DESCRIPTION
* Converts the `MultiplexedPath` returned by `package_files` to a regular `Path` in a way that is backwardly compatible.